### PR TITLE
Updated release notes template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -28,6 +28,6 @@ version-resolver:
       - 'patch'
   default: patch
 template: |
-  ## Release Notes (DD-MM-YYYY)
+  ## Release Notes (DD MM YYYY)
 
   $CHANGES


### PR DESCRIPTION
Changed `DD-MM-YYYY` to `DD MM YYYY` so we can have `13 March 2022` and avoid different date formats