### PR TITLE
Add api key to http requests

### DIFF
--- a/app/lib/repositories/door_repository.dart
+++ b/app/lib/repositories/door_repository.dart
@@ -11,33 +11,33 @@ class DoorRepository {
   final _localStorageService = LocalStorageService.instance;
 
   Future<List<Door>> findAllDoors() async {
-    String apiKey = await _localStorageService.getStringValue('global_api_key');
+    var apiKey = await _localStorageService.getStringValue('global_api_key');
+    var fqdn = await _localStorageService.getStringValue('global_fqdn');
 
-    String fqdn = await _localStorageService.getStringValue('global_fqdn');
+    var headers = <String, String>{'x-api-key': apiKey};
 
-    final res = await _httpService.get(Uri.parse('$fqdn/api/v1/doors'));
+    var res = await _httpService.get(Uri.parse('$fqdn/api/v1/doors'), headers);
 
     if (res.statusCode == 200) {
       List<dynamic> body = jsonDecode(res.body);
-
-      List<Door> doors = body
+      return body
           .map(
             (dynamic item) => Door.fromJson(item),
           )
           .toList();
-
-      return doors;
     }
 
     throw Exception(res.reasonPhrase);
   }
 
   Future<Door> findDoor(int doorId) async {
-    String apiKey = await _localStorageService.getStringValue('global_api_key');
+    var apiKey = await _localStorageService.getStringValue('global_api_key');
+    var fqdn = await _localStorageService.getStringValue('global_fqdn');
 
-    String fqdn = await _localStorageService.getStringValue('global_fqdn');
+    var headers = <String, String>{'x-api-key': apiKey};
 
-    final res = await _httpService.get(Uri.parse('$fqdn/api/v1/doors/$doorId'));
+    var res = await _httpService.get(
+        Uri.parse('$fqdn/api/v1/doors/$doorId'), headers);
 
     if (res.statusCode == 200) {
       return Door.fromJson(jsonDecode(res.body));
@@ -47,39 +47,34 @@ class DoorRepository {
   }
 
   Future<List<SequenceObject>> findDoorSequence(int doorId) async {
-    String apiKey = await _localStorageService.getStringValue('global_api_key');
+    var apiKey = await _localStorageService.getStringValue('global_api_key');
+    var fqdn = await _localStorageService.getStringValue('global_fqdn');
 
-    String fqdn = await _localStorageService.getStringValue('global_fqdn');
+    var headers = <String, String>{'x-api-key': apiKey};
 
-    final res = await _httpService
-        .get(Uri.parse('$fqdn/api/v1/doors/$doorId/sequence'));
+    var res = await _httpService.get(
+        Uri.parse('$fqdn/api/v1/doors/$doorId/sequence'), headers);
 
     if (res.statusCode == 200) {
-      print(res.body);
-
       List<dynamic> body = jsonDecode(res.body);
-
-      List<SequenceObject> doors = body
+      return body
           .map(
             (dynamic item) => SequenceObject.fromJson(item),
           )
           .toList();
-
-      return doors;
     }
 
     throw Exception(res.reasonPhrase);
   }
 
   Future<void> updateDoor(int doorId, UpdateDoor updateDoor) async {
-    print(updateDoor);
+    var apiKey = await _localStorageService.getStringValue('global_api_key');
+    var fqdn = await _localStorageService.getStringValue('global_fqdn');
 
-    String apiKey = await _localStorageService.getStringValue('global_api_key');
+    var headers = <String, String>{'x-api-key': apiKey};
 
-    String fqdn = await _localStorageService.getStringValue('global_fqdn');
-
-    final res = await _httpService.put(
-        Uri.parse('$fqdn/api/v1/doors/$doorId'), updateDoor);
+    var res = await _httpService.put(
+        Uri.parse('$fqdn/api/v1/doors/$doorId'), updateDoor, headers);
 
     if (res.statusCode == 200) {
       return;
@@ -90,12 +85,13 @@ class DoorRepository {
 
   Future<void> updateDoorSequence(
       int doorId, List<SequenceObject> sequence) async {
-    String apiKey = await _localStorageService.getStringValue('global_api_key');
+    var apiKey = await _localStorageService.getStringValue('global_api_key');
+    var fqdn = await _localStorageService.getStringValue('global_fqdn');
 
-    String fqdn = await _localStorageService.getStringValue('global_fqdn');
+    var headers = <String, String>{'x-api-key': apiKey};
 
-    final res = await _httpService.put(
-        Uri.parse('$fqdn/api/v1/doors/$doorId/sequence'), sequence);
+    var res = await _httpService.put(
+        Uri.parse('$fqdn/api/v1/doors/$doorId/sequence'), sequence, headers);
 
     if (res.statusCode == 200) {
       return;

--- a/app/lib/screens/global_settings_screen.dart
+++ b/app/lib/screens/global_settings_screen.dart
@@ -13,8 +13,8 @@ class GlobalSettingsScreen extends StatefulWidget {
 }
 
 class _GlobalSettingsScreenState extends State<GlobalSettingsScreen> {
-  String _fqdn = '';
-  String _apiKey = '';
+  var _fqdn = '';
+  var _apiKey = '';
 
   @override
   void initState() {
@@ -36,7 +36,7 @@ class _GlobalSettingsScreenState extends State<GlobalSettingsScreen> {
 
   Future<bool> _testConnection() async {
     return HttpService()
-        .get(Uri.parse(_fqdn + '/health'))
+        .get(Uri.parse(_fqdn + '/health'), null)
         .then((value) => value.statusCode == 200)
         .catchError((error) {
       return false;

--- a/app/lib/services/http_service.dart
+++ b/app/lib/services/http_service.dart
@@ -4,23 +4,26 @@ import 'package:http/http.dart' as http;
 import 'package:http/http.dart';
 
 class HttpService {
-  Future<Response> get(Uri uri) {
-    return http.get(uri);
+  Future<Response> get(Uri uri, Map<String, String>? headers) {
+    headers ??= <String, String>{};
+    headers.addAll({'Accept': 'application/json'});
+
+    return http.get(uri, headers: headers);
   }
 
-  Future<Response> post(Uri url, Object? body) {
-    return http.post(url,
-        headers: <String, String>{
-          'Content-Type': 'application/json; charset=UTF-8',
-        },
-        body: jsonEncode(body));
+  Future<Response> post(Uri url, Object? body, Map<String, String>? headers) {
+    headers ??= <String, String>{};
+    headers.addAll(
+        {'Accept': 'application/json', 'Content-Type': 'application/json'});
+
+    return http.post(url, headers: headers, body: jsonEncode(body));
   }
 
-  Future<Response> put(Uri url, Object? body) {
-    return http.put(url,
-        headers: <String, String>{
-          'Content-Type': 'application/json; charset=UTF-8',
-        },
-        body: jsonEncode(body));
+  Future<Response> put(Uri url, Object? body, Map<String, String>? headers) {
+    headers ??= <String, String>{};
+    headers.addAll(
+        {'Accept': 'application/json', 'Content-Type': 'application/json'});
+
+    return http.put(url, headers: headers, body: jsonEncode(body));
   }
 }


### PR DESCRIPTION
Previously this was not passed down so any backend that had security api requests would fail