### PR TITLE
[Service] Add test api endpoint that has authentication

### DIFF
--- a/service/src/app.module.ts
+++ b/service/src/app.module.ts
@@ -8,6 +8,7 @@ import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { MikroORM, UseRequestContext } from '@mikro-orm/core';
 import { DatabaseSeeder } from './seeders/DatabaseSeeder';
 import { Door } from './entities/Door.entity';
+import { TestModule } from './test/test.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { Door } from './entities/Door.entity';
     HealthModule,
     AutomationHatModule,
     AuthModule,
+    TestModule,
   ],
   controllers: [],
   providers: [],

--- a/service/src/test/test.controller.spec.ts
+++ b/service/src/test/test.controller.spec.ts
@@ -1,0 +1,25 @@
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthService } from '../auth/auth.service';
+import { TestController } from './test.controller';
+
+describe('TestController', () => {
+  let controller: TestController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TestController],
+      providers: [ConfigService, AuthService],
+    }).compile();
+
+    controller = module.get<TestController>(TestController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should complete successfully', async () => {
+    await controller.test();
+  });
+});

--- a/service/src/test/test.controller.ts
+++ b/service/src/test/test.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ApiResponse, ApiSecurity } from '@nestjs/swagger';
+import { ApiKeyAuthGuard } from '../auth/api-key-auth.guard';
+
+@UseGuards(ApiKeyAuthGuard)
+@ApiSecurity('api-key')
+@Controller('test')
+export class TestController {
+  @Get()
+  async test() {
+    return;
+  }
+}

--- a/service/src/test/test.module.ts
+++ b/service/src/test/test.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { TestController } from './test.controller';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [TestController],
+})
+export class TestModule {}


### PR DESCRIPTION
Add `/test` API endpoint to backend service so that we can test connection that uses authentication. Currently we just use the `/health` endpoint and this successfully works when you have auth enabled but do not provide a key. This new endpoint will return 401 so the test will be accurate.

Will open a new PR to update the apps.