### PR TITLE
(App) Test connection on authenticated endpoint

### DIFF
--- a/app/lib/screens/global_settings_screen.dart
+++ b/app/lib/screens/global_settings_screen.dart
@@ -35,8 +35,10 @@ class _GlobalSettingsScreenState extends State<GlobalSettingsScreen> {
   }
 
   Future<bool> _testConnection() async {
+    var headers = <String, String>{'x-api-key': _apiKey};
+
     return HttpService()
-        .get(Uri.parse('$_fqdn/health'), null)
+        .get(Uri.parse('$_fqdn/test'), headers)
         .then((value) => value.statusCode == 200)
         .catchError((error) {
       return false;

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.4.4+3
+version: 1.4.5+4
 
 environment:
   sdk: ">=2.16.2 <3.0.0"

--- a/service/package.json
+++ b/service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-garage",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "",
   "author": "",
   "private": true,


### PR DESCRIPTION
Update "Test Connection" on global settings screen to use new `/test` api endpoint that uses authentication. Previously this used the `/health` endpoint which does not have any authentication (not is it ever expected to). This meant that the "Test Connection" did not really check the user had the settings correct.