### PR TITLE
Ignore tests on main as this stops other concurrency ref builds

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -5,6 +5,8 @@ name: Run Unit Tests
 
 on:
   push:
+    branches-ignore:
+      - "main"
 #   push:
 #     branches: [ main ]
 #   pull_request:


### PR DESCRIPTION
Leaving tests on push to main would stop release notes running as this had the same action trigger and also had the concurrency control. The release notes action should probably be changed to pull request closed or something instead.