### PR TITLE
MacOS/Xcode 14 build machines for iOS

### DIFF
--- a/.github/workflows/release-apps.yml
+++ b/.github/workflows/release-apps.yml
@@ -56,7 +56,7 @@ jobs:
         working-directory: ./app/android
 
   ios:
-    runs-on: macos-latest
+    runs-on: macos-12 # macos-11 iTMSTransporter error until macos-latest is 12
 
     defaults:
       run:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.5.1+6
+version: 1.5.2+7
 
 environment:
   sdk: ">=2.16.2 <3.0.0"

--- a/service/package-lock.json
+++ b/service/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-garage",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-garage",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
         "@mikro-orm/core": "^5.4.2",

--- a/service/package.json
+++ b/service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-garage",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "",
   "author": "",
   "private": true,


### PR DESCRIPTION
Getting "iTMSTransporter" error with macOS 11 and Xcode 13. Advice from https://github.com/fastlane/fastlane/issues/20741 is to set environment variables or move to Xcode 14.

As GitHub macos-latest is in transition to move to macOS 12/Xcode14 (completion start of December 2022) it's probably better moving forward with this earlier and then setting back to `macos-latest` later.

I don't know the reason why this occurs as nothing changed here but currently iOS builds are broken.