### PR TITLE
[service] Client version service

### DIFF
--- a/service/package-lock.json
+++ b/service/package-lock.json
@@ -29,6 +29,7 @@
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.2",
         "rxjs": "^7.5.7",
+        "semver": "^7.3.8",
         "socket.io": "^4.5.3"
       },
       "devDependencies": {
@@ -39,6 +40,7 @@
         "@types/express": "^4.17.14",
         "@types/jest": "^27.4.1",
         "@types/node": "^18.8.4",
+        "@types/semver": "^7.3.13",
         "@types/supertest": "^2.0.11",
         "@typescript-eslint/eslint-plugin": "^5.38.1",
         "@typescript-eslint/parser": "^5.40.0",
@@ -2587,6 +2589,12 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "dev": true
+    },
+    "node_modules/@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
     },
     "node_modules/@types/serve-static": {
@@ -9188,9 +9196,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -12787,6 +12795,12 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "dev": true
+    },
+    "@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
     },
     "@types/serve-static": {
@@ -17706,9 +17720,9 @@
       }
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "requires": {
         "lru-cache": "^6.0.0"
       }

--- a/service/package.json
+++ b/service/package.json
@@ -46,6 +46,7 @@
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.5.7",
+    "semver": "^7.3.8",
     "socket.io": "^4.5.3"
   },
   "devDependencies": {
@@ -56,6 +57,7 @@
     "@types/express": "^4.17.14",
     "@types/jest": "^27.4.1",
     "@types/node": "^18.8.4",
+    "@types/semver": "^7.3.13",
     "@types/supertest": "^2.0.11",
     "@typescript-eslint/eslint-plugin": "^5.38.1",
     "@typescript-eslint/parser": "^5.40.0",

--- a/service/src/app.module.ts
+++ b/service/src/app.module.ts
@@ -10,6 +10,7 @@ import { DatabaseSeeder } from './seeders/DatabaseSeeder';
 import { Door } from './entities/Door.entity';
 import { TestModule } from './test/test.module';
 import { AuditLogsModule } from './audit-logs/audit-logs.module';
+import { ClientVersionModule } from './client-version/client-version.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { AuditLogsModule } from './audit-logs/audit-logs.module';
     AutomationHatModule,
     AuthModule,
     TestModule,
+    ClientVersionModule,
   ],
   controllers: [],
   providers: [],

--- a/service/src/client-version/client-version.module.ts
+++ b/service/src/client-version/client-version.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { ClientVersionService } from './client-version.service';
+
+@Module({
+  providers: [ClientVersionService]
+})
+export class ClientVersionModule {}

--- a/service/src/client-version/client-version.service.spec.ts
+++ b/service/src/client-version/client-version.service.spec.ts
@@ -1,0 +1,54 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ClientVersionService } from './client-version.service';
+
+describe('ClientVersionService', () => {
+  let service: ClientVersionService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ClientVersionService],
+    }).compile();
+
+    service = module.get<ClientVersionService>(ClientVersionService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should be valid for same version', () => {
+    const client = '1.5.0';
+    const server = '1.5.0';
+    expect(service.satisfies(client, server)).toEqual(true);
+  });
+
+  it('should be valid for patch versions (client > server)', () => {
+    const client = '1.5.5';
+    const server = '1.5.0';
+    expect(service.satisfies(client, server)).toEqual(true);
+  });
+
+  it('should be valid for patch versions (client < server)', () => {
+    const client = '1.5.0';
+    const server = '1.5.5';
+    expect(service.satisfies(client, server)).toEqual(true);
+  });
+
+  it('should be valid for minor versions (client > server)', () => {
+    const client = '1.6.0';
+    const server = '1.5.5';
+    expect(service.satisfies(client, server)).toEqual(true);
+  });
+
+  it('should invalid for major versions (client > server)', () => {
+    const client = '2.5.5';
+    const server = '1.5.5';
+    expect(service.satisfies(client, server)).toEqual(false);
+  });
+
+  it('should invalid for major versions (client < server)', () => {
+    const client = '1.5.5';
+    const server = '2.5.5';
+    expect(service.satisfies(client, server)).toEqual(false);
+  });
+});

--- a/service/src/client-version/client-version.service.ts
+++ b/service/src/client-version/client-version.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { valid, satisfies, gte, eq, major, minor } from 'semver';
+import { valid, satisfies, major } from 'semver';
 
 @Injectable()
 export class ClientVersionService {

--- a/service/src/client-version/client-version.service.ts
+++ b/service/src/client-version/client-version.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { valid, satisfies, gte, eq, major, minor } from 'semver';
+
+@Injectable()
+export class ClientVersionService {
+  satisfies(clientVersion: string, serverVersion: string) {
+    if (!valid(clientVersion)) {
+      throw new Error('Invalid client version string');
+    }
+
+    if (!valid(serverVersion)) {
+      throw new Error('Invalid server version string');
+    }
+
+    // support only the same major version. any minor/patch are allowed
+    const validRange = `${major(serverVersion)}.x.x`;
+
+    return satisfies(clientVersion, validRange);
+  }
+}


### PR DESCRIPTION
Create service to check client versions and return if they match minor/patch versions.

Difference in major versions will not be supported and connections will be rejected for the moment (Future releases may prompt us to allow one direction and not the other). Minor and patch version differences will be allowed and it is expected that the backend/frontend will do their best to handle it.