### PR TITLE
[service] Wire up client version guards

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "eslint.workingDirectories": ["service"]
+}

--- a/service/package-lock.json
+++ b/service/package-lock.json
@@ -29,6 +29,7 @@
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.2",
         "rxjs": "^7.5.7",
+        "semver": "^7.3.8",
         "socket.io": "^4.5.3"
       },
       "devDependencies": {
@@ -39,6 +40,7 @@
         "@types/express": "^4.17.14",
         "@types/jest": "^27.4.1",
         "@types/node": "^18.8.4",
+        "@types/semver": "^7.3.13",
         "@types/supertest": "^2.0.11",
         "@typescript-eslint/eslint-plugin": "^5.38.1",
         "@typescript-eslint/parser": "^5.40.0",
@@ -2587,6 +2589,12 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "dev": true
+    },
+    "node_modules/@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
     },
     "node_modules/@types/serve-static": {
@@ -9188,9 +9196,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -12787,6 +12795,12 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "dev": true
+    },
+    "@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
     },
     "@types/serve-static": {
@@ -17706,9 +17720,9 @@
       }
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "requires": {
         "lru-cache": "^6.0.0"
       }

--- a/service/package.json
+++ b/service/package.json
@@ -46,6 +46,7 @@
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.5.7",
+    "semver": "^7.3.8",
     "socket.io": "^4.5.3"
   },
   "devDependencies": {
@@ -56,6 +57,7 @@
     "@types/express": "^4.17.14",
     "@types/jest": "^27.4.1",
     "@types/node": "^18.8.4",
+    "@types/semver": "^7.3.13",
     "@types/supertest": "^2.0.11",
     "@typescript-eslint/eslint-plugin": "^5.38.1",
     "@typescript-eslint/parser": "^5.40.0",

--- a/service/src/app.module.ts
+++ b/service/src/app.module.ts
@@ -10,6 +10,7 @@ import { DatabaseSeeder } from './seeders/DatabaseSeeder';
 import { Door } from './entities/Door.entity';
 import { TestModule } from './test/test.module';
 import { AuditLogsModule } from './audit-logs/audit-logs.module';
+import { ClientVersionModule } from './client-version/client-version.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { AuditLogsModule } from './audit-logs/audit-logs.module';
     AutomationHatModule,
     AuthModule,
     TestModule,
+    ClientVersionModule,
   ],
   controllers: [],
   providers: [],

--- a/service/src/audit-logs/audit-logs.controller.spec.ts
+++ b/service/src/audit-logs/audit-logs.controller.spec.ts
@@ -1,6 +1,7 @@
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from '../auth/auth.service';
+import { ClientVersionModule } from '../client-version/client-version.module';
 import { AuditLogsController } from './audit-logs.controller';
 import { AuditLogsService } from './audit-logs.service';
 
@@ -26,6 +27,7 @@ describe('AuditLogsController', () => {
     };
 
     const module: TestingModule = await Test.createTestingModule({
+      imports: [ClientVersionModule],
       controllers: [AuditLogsController],
       providers: [
         AuthService,

--- a/service/src/audit-logs/audit-logs.controller.ts
+++ b/service/src/audit-logs/audit-logs.controller.ts
@@ -1,10 +1,11 @@
 import { Controller, Get, UseGuards } from '@nestjs/common';
 import { ApiSecurity } from '@nestjs/swagger';
 import { HttpApiKeyAuthGuard } from '../auth/http-api-key-auth.guard';
+import { HttpClientVersionGuard } from '../client-version/http-client-version.guard';
 import { AuditLogsService } from './audit-logs.service';
 import { AuditLogDto } from './dto/audit-log.dto';
 
-@UseGuards(HttpApiKeyAuthGuard)
+@UseGuards(HttpClientVersionGuard, HttpApiKeyAuthGuard)
 @ApiSecurity('api-key')
 @Controller('api/v1/audit-logs')
 export class AuditLogsController {

--- a/service/src/audit-logs/audit-logs.module.ts
+++ b/service/src/audit-logs/audit-logs.module.ts
@@ -4,9 +4,14 @@ import { AuditLogsController } from './audit-logs.controller';
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { AuditLog } from '../entities/AuditLog.entity';
 import { AuthModule } from '../auth/auth.module';
+import { ClientVersionModule } from '../client-version/client-version.module';
 
 @Module({
-  imports: [MikroOrmModule.forFeature([AuditLog]), AuthModule],
+  imports: [
+    MikroOrmModule.forFeature([AuditLog]),
+    AuthModule,
+    ClientVersionModule,
+  ],
   controllers: [AuditLogsController],
   providers: [AuditLogsService],
   exports: [AuditLogsService],

--- a/service/src/auth/ws-api-key-auth.guard.ts
+++ b/service/src/auth/ws-api-key-auth.guard.ts
@@ -20,7 +20,6 @@ export class WsApiKeyAuthGuard implements CanActivate {
     context: ExecutionContext,
   ): boolean | Promise<boolean> | Observable<boolean> {
     const req = context.switchToWs();
-    // .getRequest<IncomingMessage>();
 
     // if the auth service does not have a key defined then allow request
     if (!this.authService.hasApiKey()) {
@@ -34,7 +33,6 @@ export class WsApiKeyAuthGuard implements CanActivate {
       return true;
     }
 
-    // throw new UnauthorizedException();
     throw new WsException('Unauthorized');
   }
 }

--- a/service/src/client-version/client-version.module.ts
+++ b/service/src/client-version/client-version.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ClientVersionService } from './client-version.service';
 
 @Module({
-  providers: [ClientVersionService]
+  providers: [ClientVersionService],
+  exports: [ClientVersionService],
 })
 export class ClientVersionModule {}

--- a/service/src/client-version/client-version.module.ts
+++ b/service/src/client-version/client-version.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { ClientVersionService } from './client-version.service';
+
+@Module({
+  providers: [ClientVersionService]
+})
+export class ClientVersionModule {}

--- a/service/src/client-version/client-version.service.spec.ts
+++ b/service/src/client-version/client-version.service.spec.ts
@@ -1,0 +1,54 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ClientVersionService } from './client-version.service';
+
+describe('ClientVersionService', () => {
+  let service: ClientVersionService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ClientVersionService],
+    }).compile();
+
+    service = module.get<ClientVersionService>(ClientVersionService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should be valid for same version', () => {
+    const client = '1.5.0';
+    const server = '1.5.0';
+    expect(service.satisfies(client, server)).toEqual(true);
+  });
+
+  it('should be valid for patch versions (client > server)', () => {
+    const client = '1.5.5';
+    const server = '1.5.0';
+    expect(service.satisfies(client, server)).toEqual(true);
+  });
+
+  it('should be valid for patch versions (client < server)', () => {
+    const client = '1.5.0';
+    const server = '1.5.5';
+    expect(service.satisfies(client, server)).toEqual(true);
+  });
+
+  it('should be valid for minor versions (client > server)', () => {
+    const client = '1.6.0';
+    const server = '1.5.5';
+    expect(service.satisfies(client, server)).toEqual(true);
+  });
+
+  it('should invalid for major versions (client > server)', () => {
+    const client = '2.5.5';
+    const server = '1.5.5';
+    expect(service.satisfies(client, server)).toEqual(false);
+  });
+
+  it('should invalid for major versions (client < server)', () => {
+    const client = '1.5.5';
+    const server = '2.5.5';
+    expect(service.satisfies(client, server)).toEqual(false);
+  });
+});

--- a/service/src/client-version/client-version.service.spec.ts
+++ b/service/src/client-version/client-version.service.spec.ts
@@ -16,39 +16,47 @@ describe('ClientVersionService', () => {
     expect(service).toBeDefined();
   });
 
-  it('should be valid for same version', () => {
-    const client = '1.5.0';
-    const server = '1.5.0';
-    expect(service.satisfies(client, server)).toEqual(true);
+  describe('Get server version', () => {
+    it('should get server version', () => {
+      expect(service.getServerVersion()).toBeTruthy();
+    });
   });
 
-  it('should be valid for patch versions (client > server)', () => {
-    const client = '1.5.5';
-    const server = '1.5.0';
-    expect(service.satisfies(client, server)).toEqual(true);
-  });
+  describe('Satisfies', () => {
+    it('should be valid for same version', () => {
+      const client = '1.5.0';
+      const server = '1.5.0';
+      expect(service.satisfies(client, server)).toEqual(true);
+    });
 
-  it('should be valid for patch versions (client < server)', () => {
-    const client = '1.5.0';
-    const server = '1.5.5';
-    expect(service.satisfies(client, server)).toEqual(true);
-  });
+    it('should be valid for patch versions (client > server)', () => {
+      const client = '1.5.5';
+      const server = '1.5.0';
+      expect(service.satisfies(client, server)).toEqual(true);
+    });
 
-  it('should be valid for minor versions (client > server)', () => {
-    const client = '1.6.0';
-    const server = '1.5.5';
-    expect(service.satisfies(client, server)).toEqual(true);
-  });
+    it('should be valid for patch versions (client < server)', () => {
+      const client = '1.5.0';
+      const server = '1.5.5';
+      expect(service.satisfies(client, server)).toEqual(true);
+    });
 
-  it('should invalid for major versions (client > server)', () => {
-    const client = '2.5.5';
-    const server = '1.5.5';
-    expect(service.satisfies(client, server)).toEqual(false);
-  });
+    it('should be valid for minor versions (client > server)', () => {
+      const client = '1.6.0';
+      const server = '1.5.5';
+      expect(service.satisfies(client, server)).toEqual(true);
+    });
 
-  it('should invalid for major versions (client < server)', () => {
-    const client = '1.5.5';
-    const server = '2.5.5';
-    expect(service.satisfies(client, server)).toEqual(false);
+    it('should invalid for major versions (client > server)', () => {
+      const client = '2.5.5';
+      const server = '1.5.5';
+      expect(service.satisfies(client, server)).toEqual(false);
+    });
+
+    it('should invalid for major versions (client < server)', () => {
+      const client = '1.5.5';
+      const server = '2.5.5';
+      expect(service.satisfies(client, server)).toEqual(false);
+    });
   });
 });

--- a/service/src/client-version/client-version.service.ts
+++ b/service/src/client-version/client-version.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { valid, satisfies, gte, eq, major, minor } from 'semver';
+import { valid, satisfies, major } from 'semver';
 
 @Injectable()
 export class ClientVersionService {

--- a/service/src/client-version/client-version.service.ts
+++ b/service/src/client-version/client-version.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { valid, satisfies, gte, eq, major, minor } from 'semver';
+
+@Injectable()
+export class ClientVersionService {
+  satisfies(clientVersion: string, serverVersion: string) {
+    if (!valid(clientVersion)) {
+      throw new Error('Invalid client version string');
+    }
+
+    if (!valid(serverVersion)) {
+      throw new Error('Invalid server version string');
+    }
+
+    // support only the same major version. any minor/patch are allowed
+    const validRange = `${major(serverVersion)}.x.x`;
+
+    return satisfies(clientVersion, validRange);
+  }
+}

--- a/service/src/client-version/client-version.service.ts
+++ b/service/src/client-version/client-version.service.ts
@@ -1,8 +1,20 @@
 import { Injectable } from '@nestjs/common';
+import fs from 'node:fs';
 import { valid, satisfies, major } from 'semver';
 
 @Injectable()
 export class ClientVersionService {
+  getServerVersion() {
+    const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf-8'));
+    const serverVersion = packageJson.version;
+
+    if (!serverVersion) {
+      throw new Error('Failed to read server version');
+    }
+
+    return serverVersion;
+  }
+
   satisfies(clientVersion: string, serverVersion: string) {
     if (!valid(clientVersion)) {
       throw new Error('Invalid client version string');

--- a/service/src/client-version/http-client-version.guard.spec.ts
+++ b/service/src/client-version/http-client-version.guard.spec.ts
@@ -1,0 +1,54 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ClientVersionService } from './client-version.service';
+import { HttpClientVersionGuard } from './http-client-version.guard';
+
+describe('ClientVersionGuard', () => {
+  let guard: HttpClientVersionGuard;
+  let service: ClientVersionService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [HttpClientVersionGuard, ClientVersionService],
+    }).compile();
+
+    guard = module.get<HttpClientVersionGuard>(HttpClientVersionGuard);
+    service = module.get<ClientVersionService>(ClientVersionService);
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  it('should pass when a version is satisfied', async () => {
+    jest.spyOn(service, 'getServerVersion').mockReturnValue('1.2.3');
+
+    const mockContext = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          headers: {
+            'x-client-version': '1.2.3',
+          },
+        }),
+      }),
+    };
+
+    expect(guard.canActivate(mockContext as ExecutionContext)).toEqual(true);
+  });
+
+  it('should fail when a version is not satisified', async () => {
+    jest.spyOn(service, 'getServerVersion').mockReturnValue('0.0.0');
+
+    const mockContext = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          headers: {
+            'x-client-version': '1.2.3',
+          },
+        }),
+      }),
+    };
+
+    expect(guard.canActivate(mockContext as ExecutionContext)).toEqual(false);
+  });
+});

--- a/service/src/client-version/http-client-version.guard.spec.ts
+++ b/service/src/client-version/http-client-version.guard.spec.ts
@@ -20,6 +20,20 @@ describe('ClientVersionGuard', () => {
     expect(guard).toBeDefined();
   });
 
+  it('should pass when no client version given', async () => {
+    jest.spyOn(service, 'getServerVersion').mockReturnValue('1.2.3');
+
+    const mockContext = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          headers: {},
+        }),
+      }),
+    };
+
+    expect(guard.canActivate(mockContext as ExecutionContext)).toEqual(true);
+  });
+
   it('should pass when a version is satisfied', async () => {
     jest.spyOn(service, 'getServerVersion').mockReturnValue('1.2.3');
 

--- a/service/src/client-version/http-client-version.guard.ts
+++ b/service/src/client-version/http-client-version.guard.ts
@@ -1,0 +1,25 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { IncomingMessage } from 'http';
+import { Observable } from 'rxjs';
+import { ClientVersionService } from './client-version.service';
+
+@Injectable()
+export class HttpClientVersionGuard implements CanActivate {
+  constructor(private readonly clientVersionService: ClientVersionService) {}
+
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const req = context.switchToHttp().getRequest<IncomingMessage>();
+    const clientVersion = req.headers['x-client-version'] as string;
+
+    // if client version is not present allow request as we can assume this is
+    // the default latest version. this could be when a 3rd party accesses the api
+    if (!clientVersion) {
+      return true;
+    }
+
+    const serverVersion = this.clientVersionService.getServerVersion();
+    return this.clientVersionService.satisfies(clientVersion, serverVersion);
+  }
+}

--- a/service/src/client-version/ws-client-version.guard.spec.ts
+++ b/service/src/client-version/ws-client-version.guard.spec.ts
@@ -96,6 +96,8 @@ describe('WsClientVersionGuard', () => {
       },
     } as Partial<ExecutionContext>;
 
-    expect(guard.canActivate(mockContext as ExecutionContext)).toEqual(false);
+    expect(() => guard.canActivate(mockContext as ExecutionContext)).toThrow(
+      'Invalid client id',
+    );
   });
 });

--- a/service/src/client-version/ws-client-version.guard.spec.ts
+++ b/service/src/client-version/ws-client-version.guard.spec.ts
@@ -1,0 +1,101 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ClientVersionService } from './client-version.service';
+import { WsClientVersionGuard } from './ws-client-version.guard';
+
+describe('WsClientVersionGuard', () => {
+  let guard: WsClientVersionGuard;
+  let service: ClientVersionService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [WsClientVersionGuard, ClientVersionService],
+    }).compile();
+
+    guard = module.get<WsClientVersionGuard>(WsClientVersionGuard);
+    service = module.get<ClientVersionService>(ClientVersionService);
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  it('should allow if no version specified', () => {
+    jest.spyOn(service, 'getServerVersion').mockReturnValue('1.2.3');
+
+    const mockContext = {
+      switchToWs() {
+        return {
+          getData: () => {
+            return null;
+          },
+          getClient: () => {
+            return {
+              client: {
+                request: {
+                  headers: {},
+                },
+              },
+            };
+          },
+        };
+      },
+    } as Partial<ExecutionContext>;
+
+    expect(guard.canActivate(mockContext as ExecutionContext)).toEqual(true);
+  });
+
+  it('should allow a valid version', () => {
+    jest.spyOn(service, 'getServerVersion').mockReturnValue('1.2.3');
+
+    const mockContext = {
+      switchToWs() {
+        return {
+          getData: () => {
+            return null;
+          },
+          getClient: () => {
+            return {
+              client: {
+                request: {
+                  headers: {
+                    'x-client-version': '1.2.3',
+                  },
+                },
+              },
+            };
+          },
+        };
+      },
+    } as Partial<ExecutionContext>;
+
+    expect(guard.canActivate(mockContext as ExecutionContext)).toEqual(true);
+  });
+
+  it('should not allow an invalid version', () => {
+    jest.spyOn(service, 'getServerVersion').mockReturnValue('0.0.0');
+
+    const mockContext = {
+      switchToWs() {
+        return {
+          getData: () => {
+            return null;
+          },
+          getClient: () => {
+            return {
+              client: {
+                request: {
+                  headers: {
+                    'x-client-version': '1.2.3',
+                  },
+                },
+              },
+            };
+          },
+        };
+      },
+    } as Partial<ExecutionContext>;
+
+    expect(guard.canActivate(mockContext as ExecutionContext)).toEqual(false);
+  });
+});

--- a/service/src/client-version/ws-client-version.guard.ts
+++ b/service/src/client-version/ws-client-version.guard.ts
@@ -1,0 +1,27 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { Socket } from 'socket.io';
+import { ClientVersionService } from './client-version.service';
+
+@Injectable()
+export class WsClientVersionGuard implements CanActivate {
+  constructor(private readonly clientVersionService: ClientVersionService) {}
+
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const req = context.switchToWs();
+    const client = req.getClient<Socket>();
+    const clientVersion = client.client.request.headers[
+      'x-client-version'
+    ] as string;
+
+    // if no client version given assume they are match the latest
+    if (!clientVersion) {
+      return true;
+    }
+
+    const serverVersion = this.clientVersionService.getServerVersion();
+    return this.clientVersionService.satisfies(clientVersion, serverVersion);
+  }
+}

--- a/service/src/client-version/ws-client-version.guard.ts
+++ b/service/src/client-version/ws-client-version.guard.ts
@@ -1,4 +1,5 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { WsException } from '@nestjs/websockets';
 import { Observable } from 'rxjs';
 import { Socket } from 'socket.io';
 import { ClientVersionService } from './client-version.service';
@@ -22,6 +23,11 @@ export class WsClientVersionGuard implements CanActivate {
     }
 
     const serverVersion = this.clientVersionService.getServerVersion();
-    return this.clientVersionService.satisfies(clientVersion, serverVersion);
+
+    if (this.clientVersionService.satisfies(clientVersion, serverVersion)) {
+      return true;
+    }
+
+    throw new WsException('Invalid client id');
   }
 }

--- a/service/src/doors/doors.controller.spec.ts
+++ b/service/src/doors/doors.controller.spec.ts
@@ -8,6 +8,8 @@ import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from '../auth/auth.service';
 import { AutomationHatService } from '../automation-hat/automation-hat.service';
+import { ClientVersionModule } from '../client-version/client-version.module';
+import { ClientVersionService } from '../client-version/client-version.service';
 import { Door } from '../entities/Door.entity';
 import { SequenceObject } from '../entities/SequenceObject.entity';
 import { DoorsController } from './doors.controller';
@@ -79,6 +81,7 @@ describe('DoorsController', () => {
     };
 
     const module: TestingModule = await Test.createTestingModule({
+      imports: [ClientVersionModule],
       controllers: [DoorsController],
       providers: [
         ConfigService,

--- a/service/src/doors/doors.controller.ts
+++ b/service/src/doors/doors.controller.ts
@@ -16,6 +16,7 @@ import { ApiBody, ApiResponse, ApiSecurity } from '@nestjs/swagger';
 import { differenceInMilliseconds } from 'date-fns';
 import { HttpApiKeyAuthGuard } from '../auth/http-api-key-auth.guard';
 import { AutomationHatService } from '../automation-hat/automation-hat.service';
+import { HttpClientVersionGuard } from '../client-version/http-client-version.guard';
 import { SequenceObject } from '../entities/SequenceObject.entity';
 import { DoorsService } from './doors.service';
 import { GetDoorDto } from './dto/get-door.dto';
@@ -23,7 +24,7 @@ import { SequenceObjectDto } from './dto/sequence-object.dto';
 import { UpdateDoorDto } from './dto/update-door.dto';
 import { UpdateStateDto } from './dto/update-state.dto';
 
-@UseGuards(HttpApiKeyAuthGuard)
+@UseGuards(HttpClientVersionGuard, HttpApiKeyAuthGuard)
 @ApiSecurity('api-key')
 @Controller('api/v1/doors')
 export class DoorsController {

--- a/service/src/doors/doors.gateway.spec.ts
+++ b/service/src/doors/doors.gateway.spec.ts
@@ -7,12 +7,14 @@ import { Socket } from 'socket.io';
 import { Client } from 'socket.io/dist/client';
 import { DefaultEventsMap } from 'socket.io/dist/typed-events';
 import { AuthService } from '../auth/auth.service';
+import { ClientVersionService } from '../client-version/client-version.service';
 import { DoorsGateway } from './doors.gateway';
 import { DoorsService } from './doors.service';
 
 describe('DoorsGateway', () => {
   let gateway: DoorsGateway;
   let authService: AuthService;
+  let clientVersionService: ClientVersionService;
 
   const mockDoorsService = {
     findAll: jest.fn().mockResolvedValue([
@@ -42,6 +44,7 @@ describe('DoorsGateway', () => {
         },
         AuthService,
         ConfigService,
+        ClientVersionService,
       ],
     }).compile();
 

--- a/service/src/doors/doors.module.ts
+++ b/service/src/doors/doors.module.ts
@@ -7,12 +7,14 @@ import { DoorsService } from './doors.service';
 import { Door } from '../entities/Door.entity';
 import { AuditLog } from '../entities/AuditLog.entity';
 import { DoorsGateway } from './doors.gateway';
+import { ClientVersionModule } from '../client-version/client-version.module';
 
 @Module({
   imports: [
     MikroOrmModule.forFeature([Door, AuditLog]),
     AutomationHatModule,
     AuthModule,
+    ClientVersionModule,
   ],
   controllers: [DoorsController],
   providers: [DoorsService, DoorsGateway],

--- a/service/src/test/test.controller.spec.ts
+++ b/service/src/test/test.controller.spec.ts
@@ -1,6 +1,7 @@
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from '../auth/auth.service';
+import { ClientVersionModule } from '../client-version/client-version.module';
 import { TestController } from './test.controller';
 
 describe('TestController', () => {
@@ -8,6 +9,7 @@ describe('TestController', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [ClientVersionModule],
       controllers: [TestController],
       providers: [ConfigService, AuthService],
     }).compile();

--- a/service/src/test/test.controller.ts
+++ b/service/src/test/test.controller.ts
@@ -1,11 +1,16 @@
 import { Controller, Get, UseGuards } from '@nestjs/common';
-import { ApiResponse, ApiSecurity } from '@nestjs/swagger';
+import { ApiSecurity } from '@nestjs/swagger';
 import { HttpApiKeyAuthGuard } from '../auth/http-api-key-auth.guard';
+import { HttpClientVersionGuard } from '../client-version/http-client-version.guard';
 
-@UseGuards(HttpApiKeyAuthGuard)
+/**
+ * Controller for testing connection
+ */
+@UseGuards(HttpClientVersionGuard, HttpApiKeyAuthGuard)
 @ApiSecurity('api-key')
 @Controller('test')
 export class TestController {
+  // TODO: should this be under /api? ie. /api/test or /api/test-connection?
   @Get()
   async test() {
     return;

--- a/service/src/test/test.module.ts
+++ b/service/src/test/test.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
+import { ClientVersionModule } from '../client-version/client-version.module';
 import { TestController } from './test.controller';
 
 @Module({
-  imports: [AuthModule],
+  imports: [AuthModule, ClientVersionModule],
   controllers: [TestController],
 })
 export class TestModule {}


### PR DESCRIPTION
- Wire up HttpClientVersionGuard to HTTP controllers
- Wire up WsClientVersionGuard to Websockets gateways
- Update gateways handleConnect method to check for version as well. (will have to think of a better way to handle this in the future for multiple gateways if required).