### PR TITLE
[app] Fix app name on Android

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.michaelgambold.pigarage">
    <application
-        android:label="pigarage"
+        android:label="Pi Garage"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity


### PR DESCRIPTION
On Android the app name was "pigarage" instead of "Pi Garage".