### PR TITLE
Build backend service on push

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -13,7 +13,7 @@ on:
 #     branches: [ main ]
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.ref }}_run_unit_tests
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -25,7 +25,7 @@ jobs:
         working-directory: ./app
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: subosito/flutter-action@v2
         with:
@@ -50,10 +50,10 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"

--- a/.github/workflows/test-build-apps.yml
+++ b/.github/workflows/test-build-apps.yml
@@ -10,25 +10,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  android:
-    runs-on: ubuntu-latest
+  # android:
+  #   runs-on: ubuntu-latest
 
-    defaults:
-      run:
-        working-directory: ./app
+  #   defaults:
+  #     run:
+  #       working-directory: ./app
 
-    steps:
-      - uses: actions/checkout@v3
+  #   steps:
+  #     - uses: actions/checkout@v3
 
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "stable"
+  #     - uses: subosito/flutter-action@v2
+  #       with:
+  #         channel: "stable"
 
-      - name: Install packages
-        run: flutter pub get
+  #     - name: Install packages
+  #       run: flutter pub get
 
-      - name: Run Tests
-        run: flutter build apk
+  #     - name: Build apk
+  #       run: flutter build apk
 
   service:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-build-apps.yml
+++ b/.github/workflows/test-build-apps.yml
@@ -28,7 +28,7 @@ jobs:
         run: flutter pub get
 
       - name: Run Tests
-        run: flutter build appbundle
+        run: flutter build apk
 
   service:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-build-apps.yml
+++ b/.github/workflows/test-build-apps.yml
@@ -10,25 +10,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # app:
-  #   runs-on: ubuntu-latest
+  android:
+    runs-on: ubuntu-latest
 
-  #   defaults:
-  #     run:
-  #       working-directory: ./app
+    defaults:
+      run:
+        working-directory: ./app
 
-  #   steps:
-  #     - uses: actions/checkout@v2
+    steps:
+      - uses: actions/checkout@v3
 
-  #     - uses: subosito/flutter-action@v2
-  #       with:
-  #         channel: "stable"
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
 
-  #     - name: Install packages
-  #       run: flutter pub get
+      - name: Install packages
+        run: flutter pub get
 
-  #     - name: Run Tests
-  #       run: flutter test
+      - name: Run Tests
+        run: flutter build appbundle
 
   service:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-build-apps.yml
+++ b/.github/workflows/test-build-apps.yml
@@ -1,0 +1,54 @@
+name: Test Build Apps
+
+on:
+  push:
+    branches-ignore:
+      - "main"
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # app:
+  #   runs-on: ubuntu-latest
+
+  #   defaults:
+  #     run:
+  #       working-directory: ./app
+
+  #   steps:
+  #     - uses: actions/checkout@v2
+
+  #     - uses: subosito/flutter-action@v2
+  #       with:
+  #         channel: "stable"
+
+  #     - name: Install packages
+  #       run: flutter pub get
+
+  #     - name: Run Tests
+  #       run: flutter test
+
+  service:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./service
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: 18.x
+          cache: "npm"
+          cache-dependency-path: service/package-lock.json
+
+      - name: Install packages
+        run: npm ci
+
+      - name: Run Tests
+        run: npm run build

--- a/.github/workflows/test-build-apps.yml
+++ b/.github/workflows/test-build-apps.yml
@@ -6,7 +6,7 @@ on:
       - "main"
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.ref }}_test_build_apps
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-build-apps.yml
+++ b/.github/workflows/test-build-apps.yml
@@ -38,10 +38,10 @@ jobs:
         working-directory: ./service
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 18.x
           cache: "npm"


### PR DESCRIPTION
Build backend service on code push to ensure it builds on CI before code merge.

Apps (Android) has been skeleton'd out but would not pass CI and have to dig into it a bit more.