### PR TITLE
[app] Current Config Provider

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
-import 'services/migration_service.dart';
-import 'screens/door_sequence_screen.dart';
-import 'screens/door_settings_screen.dart';
-import 'screens/home_screen.dart';
-import 'screens/global_settings_screen.dart';
-import 'screens/audit_log_screen.dart';
+import 'package:pi_garage/providers/current_config_provider.dart';
+import 'package:pi_garage/screens/door_sequence_screen.dart';
+import 'package:pi_garage/screens/door_settings_screen.dart';
+import 'package:pi_garage/screens/home_screen.dart';
+import 'package:pi_garage/screens/global_settings_screen.dart';
+import 'package:pi_garage/screens/audit_log_screen.dart';
+import 'package:pi_garage/services/migration_service.dart';
+import 'package:provider/provider.dart';
 
 Future<void> main() async {
   try {
@@ -13,7 +15,10 @@ Future<void> main() async {
     final migrationService = MigrationService();
     await migrationService.runAll();
 
-    runApp(const MyApp());
+    runApp(ChangeNotifierProvider(
+      create: (context) => CurrentConfigProvider(),
+      child: const MyApp(),
+    ));
   } catch (error) {
     // If an error occurs, show the error message on the screen
     runApp(MaterialApp(

--- a/app/lib/providers/current_config_provider.dart
+++ b/app/lib/providers/current_config_provider.dart
@@ -16,7 +16,7 @@ class CurrentConfigProvider extends ChangeNotifier {
     });
   }
 
-  setCurrentConfig(String id) async {
+  Future<void> setCurrentConfig(String id) async {
     final configRepo = ConfigRepository();
     await configRepo.setCurrentConfig(id);
     _currentConfig = await configRepo.findCurrentConfig();

--- a/app/lib/providers/current_config_provider.dart
+++ b/app/lib/providers/current_config_provider.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/config.dart';
+import '../repositories/config_repository.dart';
+
+class CurrentConfigProvider extends ChangeNotifier {
+  Config? _currentConfig;
+
+  Config? get currentConfig => _currentConfig;
+
+  CurrentConfigProvider() {
+    final configRepo = ConfigRepository();
+    configRepo.findCurrentConfig().then((value) {
+      _currentConfig = value;
+      notifyListeners();
+    });
+  }
+
+  setCurrentConfig(String id) async {
+    final configRepo = ConfigRepository();
+    await configRepo.setCurrentConfig(id);
+    _currentConfig = await configRepo.findCurrentConfig();
+    notifyListeners();
+  }
+}

--- a/app/lib/repositories/config_repository.dart
+++ b/app/lib/repositories/config_repository.dart
@@ -37,7 +37,7 @@ class ConfigRepository {
     await updateAllConfigs(configs);
   }
 
-  Future<void> selectConfig(String id) async {
+  Future<void> setCurrentConfig(String id) async {
     final localStorageService = LocalStorageService.instance;
     await localStorageService.setStringValue('currentConfigId', id);
   }

--- a/app/lib/services/api_service.dart
+++ b/app/lib/services/api_service.dart
@@ -1,41 +1,42 @@
 import 'package:http/http.dart';
+import 'package:pi_garage/models/config.dart';
+import 'package:pi_garage/repositories/config_repository.dart';
 
 import 'app_version_service.dart';
 import 'http_service.dart';
-import 'local_storage_service.dart';
 
 class ApiService {
   final _httpService = HttpService();
-  final _localStorageService = LocalStorageService.instance;
+  final _configRepo = ConfigRepository();
   final _appVersionService = AppVersionService();
 
   Future<Response> get(String path) async {
-    final fqdn = await _localStorageService.getStringValue('global_fqdn');
-    final uri = Uri.parse('$fqdn$path');
-    final headers = await _getHeaders();
+    final config = await _configRepo.findCurrentConfig();
+    final uri = Uri.parse('${config.fqdn}$path');
+    final headers = await _getHeaders(config);
     return _httpService.get(uri, headers);
   }
 
   Future<Response> post(String path, Object? body) async {
-    final fqdn = await _localStorageService.getStringValue('global_fqdn');
-    final uri = Uri.parse('$fqdn$path');
-    final headers = await _getHeaders();
+    final config = await _configRepo.findCurrentConfig();
+    final uri = Uri.parse('${config.fqdn}$path');
+    final headers = await _getHeaders(config);
     return _httpService.post(uri, body, headers);
   }
 
   Future<Response> put(String path, Object? body) async {
-    final fqdn = await _localStorageService.getStringValue('global_fqdn');
-    final uri = Uri.parse('$fqdn$path');
-    final headers = await _getHeaders();
+    final config = await _configRepo.findCurrentConfig();
+    final uri = Uri.parse('${config.fqdn}$path');
+    final headers = await _getHeaders(config);
     return _httpService.post(uri, body, headers);
   }
 
-  _getHeaders() async {
-    final apiKey = await _localStorageService.getStringValue('global_api_key');
+  _getHeaders(Config config) async {
     final clientVersion = await _appVersionService.getAppVersion();
 
     final headers = <String, String>{};
-    headers.addAll({'x-api-key': apiKey, 'x-client-version': clientVersion});
+    headers.addAll(
+        {'x-api-key': config.apiKey ?? "", 'x-client-version': clientVersion});
     return headers;
   }
 }

--- a/app/lib/services/current_config_service.dart
+++ b/app/lib/services/current_config_service.dart
@@ -1,0 +1,18 @@
+import '../models/config.dart';
+import '../repositories/config_repository.dart';
+
+class CurrentConfigService {
+  static final CurrentConfigService _instance =
+      CurrentConfigService._internal();
+
+  late Config currentConfig;
+
+  factory CurrentConfigService() {
+    return _instance;
+  }
+
+  CurrentConfigService._internal() {
+    final configRepo = ConfigRepository();
+    configRepo.findCurrentConfig().then((value) => currentConfig = value);
+  }
+}

--- a/app/lib/services/migration_service.dart
+++ b/app/lib/services/migration_service.dart
@@ -30,7 +30,7 @@ class MigrationService {
     final config = Config(uuid.v4(), "default", fqdn, apiKey);
 
     await configRepo.updateAllConfigs([config]);
-    await configRepo.selectConfig(config.id);
+    await configRepo.setCurrentConfig(config.id);
 
     // remove old config items
     await localStorage.removeValue('global_fqdn');

--- a/app/lib/widgets/menu_drawer.dart
+++ b/app/lib/widgets/menu_drawer.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:pi_garage/models/config.dart';
+import 'package:pi_garage/providers/current_config_provider.dart';
 import 'package:pi_garage/repositories/config_repository.dart';
+import 'package:pi_garage/services/app_version_service.dart';
 import 'package:pi_garage/widgets/config_dropdown.dart';
-
-import '../services/app_version_service.dart';
+import 'package:provider/provider.dart';
 
 class MenuDrawer extends StatefulWidget {
   const MenuDrawer({Key? key}) : super(key: key);
@@ -19,7 +20,6 @@ class _MenuDrawerState extends State<MenuDrawer> {
 
   String _appVersion = '';
   List<Config> _configs = [];
-  Config? _currentConfig;
 
   @override
   void initState() {
@@ -31,23 +31,13 @@ class _MenuDrawerState extends State<MenuDrawer> {
     _configRepository.findAllConfigs().then((value) => setState(() {
           _configs = value;
         }));
-    _refreshCurrentConfig();
-  }
-
-  Future<void> _refreshCurrentConfig() async {
-    final currentConfig = await _configRepository.findCurrentConfig();
-    setState(() {
-      _currentConfig = currentConfig;
-    });
-  }
-
-  Future<void> _selectConfig(String value) async {
-    await _configRepository.selectConfig(value);
-    await _refreshCurrentConfig();
   }
 
   @override
   Widget build(BuildContext context) {
+    final currentConfigProvider = context.watch<CurrentConfigProvider>();
+    final currentConfig = currentConfigProvider.currentConfig;
+
     return Drawer(
       child: ListView(
         padding: EdgeInsets.zero,
@@ -73,8 +63,9 @@ class _MenuDrawerState extends State<MenuDrawer> {
                           ),
                           ConfigDropdown(
                               configs: _configs,
-                              currentConfigId: _currentConfig?.id,
-                              onChange: (value) => _selectConfig(value))
+                              currentConfigId: currentConfig?.id,
+                              onChange: (value) =>
+                                  currentConfigProvider.setCurrentConfig(value))
                         ])),
                     SizedBox(
                         height: _appVersionTextSize,

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -320,6 +320,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.3.2"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   package_config:
     dependency: transitive
     description:
@@ -408,6 +416,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.4"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      sha256: cdbe7530b12ecd9eb455bdaa2fcb8d4dad22e80b8afb4798b41479d5ce26847f
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.5"
   pub_semver:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   socket_io_client: ^2.0.1
   package_info_plus: ^3.0.3
   uuid: ^3.0.7
+  provider: ^6.0.5
 
 dev_dependencies:
   flutter_test:

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -9,11 +9,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:pi_garage/main.dart';
+import 'package:pi_garage/providers/current_config_provider.dart';
+import 'package:provider/provider.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(ChangeNotifierProvider(
+      create: (context) => CurrentConfigProvider(),
+      child: const MyApp(),
+    ));
 
     // Verify that our counter starts at 0.
     // expect(find.text('0'), findsOneWidget);

--- a/service/src/audit-logs/audit-logs.controller.ts
+++ b/service/src/audit-logs/audit-logs.controller.ts
@@ -1,4 +1,10 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
+import {
+  ConsoleLogger,
+  Controller,
+  Get,
+  LoggerService,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiSecurity } from '@nestjs/swagger';
 import { HttpApiKeyAuthGuard } from '../auth/http-api-key-auth.guard';
 import { HttpClientVersionGuard } from '../client-version/http-client-version.guard';
@@ -9,10 +15,16 @@ import { AuditLogDto } from './dto/audit-log.dto';
 @ApiSecurity('api-key')
 @Controller('api/v1/audit-logs')
 export class AuditLogsController {
-  constructor(private readonly auditLogsService: AuditLogsService) {}
+  #logger: LoggerService;
+
+  constructor(private readonly auditLogsService: AuditLogsService) {
+    this.#logger = new ConsoleLogger(AuditLogsController.name);
+  }
 
   @Get()
   async getAll(): Promise<AuditLogDto[]> {
+    this.#logger.log('GET /api/v1/audit-logs invoked');
+
     const auditLogs = await this.auditLogsService.findAll();
 
     return auditLogs.map((x) => {


### PR DESCRIPTION
- Refactor relative imports to explicit package:pi_garage/*
- Import provider package
- Create CurrentConfigProvider
- Wire CurrentConfigProvider into home list screen and into menu drawer component
- Recreate socket.io socket when config changes (but not on every run of the build() method)
- Update ApiService to get current config on every API request (maybe this could be cached in memory)