### PR TITLE
[app] Current config not refreshed when edited

### DIFF
--- a/app/lib/providers/current_config_provider.dart
+++ b/app/lib/providers/current_config_provider.dart
@@ -22,4 +22,10 @@ class CurrentConfigProvider extends ChangeNotifier {
     _currentConfig = await configRepo.findCurrentConfig();
     notifyListeners();
   }
+
+  Future<void> reloadCurrentConfig() async {
+    final configRepo = ConfigRepository();
+    _currentConfig = await configRepo.findCurrentConfig();
+    notifyListeners();
+  }
 }

--- a/app/lib/screens/edit_config_screen.dart
+++ b/app/lib/screens/edit_config_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:pi_garage/models/config.dart';
+import 'package:pi_garage/providers/current_config_provider.dart';
 import 'package:pi_garage/repositories/config_repository.dart';
 import 'package:pi_garage/services/http_service.dart';
+import 'package:provider/provider.dart';
 
 class EditConfigScreen extends StatefulWidget {
   const EditConfigScreen(
@@ -127,6 +129,8 @@ class _EditConfigScreenState extends State<EditConfigScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final currentConfigProvider = context.watch<CurrentConfigProvider>();
+    final currentConfig = currentConfigProvider.currentConfig;
     _scaffoldMesseger = ScaffoldMessenger.of(context);
 
     return Scaffold(
@@ -185,6 +189,9 @@ class _EditConfigScreenState extends State<EditConfigScreen> {
                         return;
                       }
                       await _handleSave();
+                      if (currentConfig?.id == _config.id) {
+                        await currentConfigProvider.reloadCurrentConfig();
+                      }
                     },
                     child: const Text('Save'),
                   ),

--- a/app/lib/screens/home_screen.dart
+++ b/app/lib/screens/home_screen.dart
@@ -79,13 +79,35 @@ class _HomeScreenState extends State<HomeScreen> {
     await _initSocket(_config!.fqdn, _config!.apiKey ?? '');
   }
 
+  bool configChanged(Config? prevConfig, Config? toTest) {
+    if (toTest == null) {
+      return false;
+    }
+    if (prevConfig == null) {
+      return true;
+    }
+    if (toTest.id != prevConfig.id) {
+      return true;
+    }
+    if (toTest.name != prevConfig.name) {
+      return true;
+    }
+    if (toTest.fqdn != prevConfig.fqdn) {
+      return true;
+    }
+    if (toTest.apiKey != prevConfig.apiKey) {
+      return true;
+    }
+    return false;
+  }
+
   @override
   Widget build(BuildContext context) {
     // get current config from provider
     final currentConfigProvider = context.watch<CurrentConfigProvider>();
     final currentConfig = currentConfigProvider.currentConfig;
 
-    if (currentConfig?.id != _config?.id) {
+    if (configChanged(_config, currentConfig)) {
       _config = currentConfig;
       _refresh();
     }


### PR DESCRIPTION
The current config (i.e. list of doors) was not refreshed when the config id was not changed. If you changed the config then it would "fix" itself but for Pi Garage's that only have one config you would have to kill the app to reload the config.