### PR TITLE
[service] Add door open/close duration properties

### DIFF
--- a/service/src/doors/doors.controller.spec.ts
+++ b/service/src/doors/doors.controller.spec.ts
@@ -48,18 +48,24 @@ describe('DoorsController', () => {
           isEnabled: true,
           label: 'door1',
           state: 'open',
+          closeDuration: 20_000,
+          openDuration: 20_000,
         },
         {
           id: 2,
           isEnabled: true,
           label: 'door2',
           state: 'open',
+          closeDuration: 20_000,
+          openDuration: 20_000,
         },
         {
           id: 3,
           isEnabled: true,
           label: 'door3',
           state: 'open',
+          closeDuration: 20_000,
+          openDuration: 20_000,
         },
       ]),
       findOne: jest.fn().mockImplementation(async (id: number) => {
@@ -134,18 +140,24 @@ describe('DoorsController', () => {
           isEnabled: true,
           label: 'door1',
           state: 'open',
+          closeDuration: 20_000,
+          openDuration: 20_000,
         },
         {
           id: 2,
           isEnabled: true,
           label: 'door2',
           state: 'open',
+          closeDuration: 20_000,
+          openDuration: 20_000,
         },
         {
           id: 3,
           isEnabled: true,
           label: 'door3',
           state: 'open',
+          closeDuration: 20_000,
+          openDuration: 20_000,
         },
       ];
 
@@ -212,7 +224,12 @@ describe('DoorsController', () => {
 
   describe('Update Door', () => {
     it('should return 200 when given valid update request', async () => {
-      await controller.update(1, { isEnabled: true, label: 'new label' });
+      await controller.update(1, {
+        isEnabled: true,
+        label: 'new label',
+        closeDuration: 20_000,
+        openDuration: 20_000,
+      });
 
       expect(commsOffSpy).toBeCalled();
       expect(commsOnSpy).toBeCalled();

--- a/service/src/doors/doors.controller.ts
+++ b/service/src/doors/doors.controller.ts
@@ -64,6 +64,8 @@ export class DoorsController {
         label: d.label,
         isEnabled: d.isEnabled,
         state: d.state,
+        openDuration: d.openDuration,
+        closeDuration: d.closeDuration,
       };
     });
   }
@@ -88,6 +90,8 @@ export class DoorsController {
       label: door.label,
       isEnabled: door.isEnabled,
       state: door.state,
+      openDuration: door.openDuration,
+      closeDuration: door.closeDuration,
     };
   }
 
@@ -132,6 +136,8 @@ export class DoorsController {
     const door = await this.doorsService.findOne(id);
     door.isEnabled = body.isEnabled;
     door.label = body.label;
+    door.closeDuration = body.closeDuration;
+    door.openDuration = body.openDuration;
 
     await this.doorsService.update(door);
 

--- a/service/src/doors/dto/get-door.dto.ts
+++ b/service/src/doors/dto/get-door.dto.ts
@@ -10,6 +10,12 @@ export class GetDoorDto {
   @ApiProperty()
   isEnabled: boolean;
 
+  @ApiProperty()
+  openDuration: number;
+
+  @ApiProperty()
+  closeDuration: number;
+
   @ApiProperty({ enum: ['open', 'opening', 'closed', 'closing'] })
   state: 'open' | 'opening' | 'closed' | 'closing';
 }

--- a/service/src/doors/dto/update-door.dto.ts
+++ b/service/src/doors/dto/update-door.dto.ts
@@ -6,4 +6,10 @@ export class UpdateDoorDto {
 
   @ApiProperty()
   isEnabled: boolean;
+
+  @ApiProperty()
+  openDuration: number;
+
+  @ApiProperty()
+  closeDuration: number;
 }

--- a/service/src/entities/Door.entity.ts
+++ b/service/src/entities/Door.entity.ts
@@ -25,6 +25,12 @@ export class Door {
   @Property()
   state: 'open' | 'opening' | 'closed' | 'closing';
 
+  @Property({ default: 20_000 })
+  openDuration: number;
+
+  @Property({ default: 20_000 })
+  closeDuration: number;
+
   @OneToMany(() => SequenceObject, (sequenceObject) => sequenceObject.door, {
     orderBy: { index: QueryOrder.ASC },
     orphanRemoval: true,

--- a/service/src/migrations/.snapshot-pi-garage.sqlite3.json
+++ b/service/src/migrations/.snapshot-pi-garage.sqlite3.json
@@ -95,6 +95,26 @@
           "primary": false,
           "nullable": false,
           "mappedType": "text"
+        },
+        "open_duration": {
+          "name": "open_duration",
+          "type": "integer",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "20000",
+          "mappedType": "integer"
+        },
+        "close_duration": {
+          "name": "close_duration",
+          "type": "integer",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "20000",
+          "mappedType": "integer"
         }
       },
       "name": "door",

--- a/service/src/migrations/Migration20231103104030.ts
+++ b/service/src/migrations/Migration20231103104030.ts
@@ -1,0 +1,10 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20231103104030 extends Migration {
+
+  async up(): Promise<void> {
+    this.addSql('alter table `door` add column `open_duration` integer not null default 20000;');
+    this.addSql('alter table `door` add column `close_duration` integer not null default 20000;');
+  }
+
+}

--- a/service/src/seeders/DatabaseSeeder.ts
+++ b/service/src/seeders/DatabaseSeeder.ts
@@ -12,6 +12,8 @@ export class DatabaseSeeder extends Seeder {
         label: `Door 1`,
         isEnabled: true,
         state: 'closed',
+        openDuration: 20_000,
+        closeDuration: 20_000,
         sequence: [
           {
             action: 'on',
@@ -39,6 +41,8 @@ export class DatabaseSeeder extends Seeder {
         label: `Door 2`,
         isEnabled: true,
         state: 'closed',
+        openDuration: 20_000,
+        closeDuration: 20_000,
         sequence: [
           {
             action: 'on',
@@ -66,6 +70,8 @@ export class DatabaseSeeder extends Seeder {
         label: `Door 3`,
         isEnabled: true,
         state: 'closed',
+        openDuration: 20_000,
+        closeDuration: 20_000,
         sequence: [
           {
             action: 'on',


### PR DESCRIPTION
## Description

- Add `openDuration` and `closeDuration` to entity/dto objects.
- Created migration to create properties and set them to default value. Update initial seed to set these to default value.
- Updated tests to include properties.