### PR TITLE
Revert always load in service but copy like in controller

### DIFF
--- a/service/src/doors/doors-sequence-processor.ts
+++ b/service/src/doors/doors-sequence-processor.ts
@@ -44,10 +44,11 @@ export class DoorsSequenceProcessor extends WorkerHost {
 
   private async close(data: DoorsSequenceJobData): Promise<void> {
     const door = await this.doorsService.findOne(data.doorId);
+    await door.sequence.init();
 
     this.logger.log(`Running sequence for door ${data.doorId}`);
 
-    for (const sequenceObject of door.sequence) {
+    for (const sequenceObject of door.sequence.getItems()) {
       await this.automationHatService.runSequenceObject(sequenceObject);
     }
 
@@ -56,10 +57,11 @@ export class DoorsSequenceProcessor extends WorkerHost {
 
   private async open(data: DoorsSequenceJobData): Promise<void> {
     const door = await this.doorsService.findOne(data.doorId);
+    await door.sequence.init();
 
     this.logger.log(`Running sequence for door ${data.doorId}`);
 
-    for (const sequenceObject of door.sequence) {
+    for (const sequenceObject of door.sequence.getItems()) {
       await this.automationHatService.runSequenceObject(sequenceObject);
     }
 

--- a/service/src/doors/doors.service.ts
+++ b/service/src/doors/doors.service.ts
@@ -48,7 +48,7 @@ export class DoorsService {
   }
 
   findOne(id: number) {
-    return this.doorRepository.findOne({ id }, { populate: ['sequence'] });
+    return this.doorRepository.findOne({ id });
   }
 
   // async open(id: number): Promise<void> {


### PR DESCRIPTION
## Description

Revert #383 and do the import the same way as the door controller "get sequences". Do it like this to avoid a clash in loading the related entities multiple ways.