### PR TITLE
Always load sequence

### DIFF
--- a/service/src/doors/doors.service.ts
+++ b/service/src/doors/doors.service.ts
@@ -48,7 +48,7 @@ export class DoorsService {
   }
 
   findOne(id: number) {
-    return this.doorRepository.findOne({ id });
+    return this.doorRepository.findOne({ id }, { populate: ['sequence'] });
   }
 
   // async open(id: number): Promise<void> {


### PR DESCRIPTION
## Description

Always load door sequences to return from the repository.

## Issue

When returning a door object the orm was not populating the "sequence" property. This meant it just ignored processing a sequence and did not communicate to the underlying hardware (i.e. open/close a relay).