### PR TITLE
Test only 2 stages

### DIFF
--- a/service/.npmrc
+++ b/service/.npmrc
@@ -1,2 +1,0 @@
-fetch-retry-maxtimeout = 6000000
-fetch-retry-mintimeout = 1000000

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -11,7 +11,18 @@ COPY . .
 RUN npm run build
 
 
-FROM node:18 as prod-deps
+# FROM node:18 as prod-deps
+
+# WORKDIR /app
+
+# COPY package*.json ./
+
+# RUN npm ci --omit=dev
+
+
+FROM node:18
+
+ENV NODE_ENV=production
 
 WORKDIR /app
 
@@ -19,17 +30,8 @@ COPY package*.json ./
 
 RUN npm ci --omit=dev
 
-
-FROM node:18-slim
-
-ENV NODE_ENV=production
-
-WORKDIR /app
-
-COPY package.json ./
-
 COPY --from=build /app/dist ./dist
 
-COPY --from=prod-deps /app/node_modules ./node_modules
+# COPY --from=prod-deps /app/node_modules ./node_modules
 
 ENTRYPOINT [ "node", "dist/main.js" ]

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -4,8 +4,6 @@ WORKDIR /app
 
 COPY package*.json ./
 
-COPY .npmrc ./
-
 RUN npm ci
 
 COPY . .
@@ -18,8 +16,6 @@ FROM node:18 as prod-deps
 WORKDIR /app
 
 COPY package*.json ./
-
-COPY .npmrc ./
 
 RUN npm ci --omit=dev
 


### PR DESCRIPTION
## Description

Revert npmrc timeouts. Try making only 2 stages in dockerfile so that it npm ci will wait instead of trying to do ci and dev ci at same time.