### PR TITLE
Use workflow dispatch to release apps

### DIFF
--- a/.github/workflows/release-apps.yml
+++ b/.github/workflows/release-apps.yml
@@ -1,8 +1,7 @@
 name: Release Apps
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
 
 env:
   FLUTTER_VERSION: 3.22.0


### PR DESCRIPTION
## Description

Break the link between publishing releases and deploying code. This also allows us to replay tags/releases if required as well as skip release candidates if we choose.