### PR TITLE
Use macOS 15 for iOS build

### DIFF
--- a/.github/workflows/release-apps.yml
+++ b/.github/workflows/release-apps.yml
@@ -61,7 +61,7 @@ jobs:
         working-directory: ./app/android
 
   ios:
-    runs-on: macos-latest
+    runs-on: macos-15
 
     defaults:
       run:

--- a/.github/workflows/test-build-apps.yml
+++ b/.github/workflows/test-build-apps.yml
@@ -46,7 +46,7 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
   ios:
-    runs-on: macos-latest
+    runs-on: macos-15
 
     defaults:
       run:


### PR DESCRIPTION
## Description

The `macos-latest` image has not been updated to macOS 15 yet which has Xcode 16 as the default. Since this is the same version as dev machines we will just sync this with the dev machines.