### PR TITLE
Fix test build apps

### DIFF
--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -15,7 +15,7 @@ fun getLocalProperty(key: String, defaultValue: String): String {
 val flutterVersionCode = getLocalProperty("flutter.versionCode", "1").toInt()
 val flutterVersionName = getLocalProperty("flutter.versionName", "1.0")
 
-val keystorePropertiesFile = rootProject.file("keystore.properties")
+val keystorePropertiesFile = rootProject.file("key.properties")
 val keystoreProperties = Properties().apply {
     if (keystorePropertiesFile.exists()) {
         load(FileInputStream(keystorePropertiesFile))

--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -1,6 +1,20 @@
 import java.util.Properties
 import java.io.FileInputStream
 
+val localPropertiesFile = rootProject.file("local.properties")
+val localProperties = Properties().apply {
+    if (localPropertiesFile.exists()) {
+        load(FileInputStream(localPropertiesFile))
+    }
+}
+
+fun getLocalProperty(key: String, defaultValue: String): String {
+    return localProperties.getProperty(key) ?: defaultValue
+}
+
+val flutterVersionCode = getLocalProperty("flutter.versionCode", "1").toInt()
+val flutterVersionName = getLocalProperty("flutter.versionName", "1.0")
+
 val keystorePropertiesFile = rootProject.file("keystore.properties")
 val keystoreProperties = Properties().apply {
     if (keystorePropertiesFile.exists()) {
@@ -40,8 +54,8 @@ android {
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
-        versionCode = flutter.versionCode
-        versionName = flutter.versionName
+        versionCode = flutterVersionCode
+        versionName = flutterVersionName
     }
 
     signingConfigs {

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 3.0.5+33
+version: 3.0.5+34
 
 environment:
   sdk: ">=2.16.2 <3.0.0"


### PR DESCRIPTION
## Description

Update Gradle config to read local properties and use a default if none given. Use `key.properties` to get key information instead of `keystore.properties` as it is already in the `.gitignore` file.