### PR TITLE
Fix dynamic import issue from mikroORM crashing tests

### DIFF
--- a/pi-garage.code-workspace
+++ b/pi-garage.code-workspace
@@ -8,6 +8,8 @@
     }
   ],
   "settings": {
-    "jest.disabledWorkspaceFolders": ["app"]
+    "jest.disabledWorkspaceFolders": ["app"],
+    "typescript.tsserver.nodePath": "node",
+    "eslint.runtime": "node"
   }
 }

--- a/service/package.json
+++ b/service/package.json
@@ -88,8 +88,16 @@
     "rootDir": "./src",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
+      "^.+\\.(t|j)s$": [
+        "ts-jest",
+        {
+          "useESM": true
+        }
+      ]
     },
+    "transformIgnorePatterns": [
+      "node_modules/(?!@mikro-orm)"
+    ],
     "collectCoverageFrom": [
       "**/*.(t|j)s",
       "!**/*.module.ts",


### PR DESCRIPTION
## Description

Update jest settings to handle mikroORM dynamic imports and not crash tests.

NOTE: When asking Copilot it said that we needed to update from commonJS as the deployment. I tried this and it just broke and would not run when running `npm run build` and trying to run this with `npm run start:prod`. When I reverted and built with `commonjs` and could run the tests, prod builds and run in the container so going to leave this commonJS unless there is a reason to not do this.